### PR TITLE
Update dead Programming with Comics link

### DIFF
--- a/notes/bret-victor/index.md
+++ b/notes/bret-victor/index.md
@@ -107,7 +107,7 @@ Beautiful. Yet unclear what problem it solves for whom.
 
 ## _May 2013_ - [Drawing Dynamic Visualizations](https://vimeo.com/66085662) 
 
-Beautiful. Reminds me both of JoyJS and Aprt.us and [Programming with Comics](http://whynotfireworks.com/programming-with-comics/). Crazy how many tools this man inspires!
+Beautiful. Reminds me both of JoyJS and Aprt.us and [Programming with Comics](https://nearthespeedoflight.com/programming-with-comics/). Crazy how many tools this man inspires!
 
 ### [Additional Notes on "Drawing Dynamic Visualizations"](http://worrydream.com/DrawingDynamicVisualizationsTalkAddendum/)
 


### PR DESCRIPTION
[wayback machine for old link](https://web.archive.org/web/20161018211200/http://whynotfireworks.com/programming-with-comics) broke the all-important visualizations.
Seems it just moved domains.  Oh yes, here is blog post about the move: https://nearthespeedoflight.com/article/2018_08_20_retiring_why_not_fireworks